### PR TITLE
【Bug】修复`onChange`方法内获取到的value依然是旧值的问题

### DIFF
--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -33,17 +33,6 @@ function EditorComponent(props: Partial<IProps>) {
     if (onCreatedFromConfig) onCreatedFromConfig(editor)
   }
 
-  const handleChanged = (editor: IDomEditor) => {
-    setCurValue(editor.getHtml()) // 记录当前 html 值
-
-    // 组件属性 onChange
-    if (onChange) onChange(editor)
-
-    // 编辑器 配置 onChange
-    const { onChange: onChangeFromConfig } = defaultConfig
-    if (onChangeFromConfig) onChangeFromConfig(editor)
-  }
-
   const handleDestroyed = (editor: IDomEditor) => {
     const { onDestroyed } = defaultConfig
     setEditor(null)
@@ -51,6 +40,21 @@ function EditorComponent(props: Partial<IProps>) {
       onDestroyed(editor)
     }
   }
+
+  useEffect(() => {
+    if (editor == null) return
+
+    editor.__react_on_change = (e: IDomEditor) => {
+      setCurValue(e.getHtml()) // 记录当前 html 值
+  
+      // 组件属性 onChange
+      if (onChange) onChange(e)
+  
+      // 编辑器 配置 onChange
+      const { onChange: onChangeFromConfig } = defaultConfig
+      if (onChangeFromConfig) onChangeFromConfig(e)
+    }
+  }, [editor, defaultConfig])
 
   // value 变化，重置 HTML
   useEffect(() => {
@@ -78,7 +82,7 @@ function EditorComponent(props: Partial<IProps>) {
       config: {
         ...defaultConfig,
         onCreated: handleCreated,
-        onChange: handleChanged,
+        onChange: (e: IDomEditor)=> newEditor?.__react_on_change?.(e),
         onDestroyed: handleDestroyed,
       },
       content: defaultContent,


### PR DESCRIPTION
复现代码
```
import { useEffect, useState } from "react";
import "@wangeditor-next/editor/dist/css/style.css"; // 引入 css
import { Editor, Toolbar } from "@wangeditor-next/editor-for-react";
import { createEditor } from "@wangeditor-next/editor";

const MyEditor = (props) => {
  const { value, onChange } = props;

  // editor 实例
  const [editor, setEditor] = useState(null);

  // 工具栏配置
  const toolbarConfig = {};

  // 编辑器配置
  const editorConfig = {};

  const handleChange = (e) => {
    console.log(value);
    onChange?.(e.getHtml());
  };

  // 及时销毁 editor ，重要！
  useEffect(() => {
    return () => {
      if (editor == null) {
        return;
      }
      editor.destroy();
      setEditor(null);
    };
  }, [editor]);

  return (
    <div>
      <Toolbar editor={editor} defaultConfig={toolbarConfig} mode="default" />
      <Editor
        defaultConfig={editorConfig}
        value={value}
        onCreated={setEditor}
        onChange={(e) => handleChange(e)}
        mode="default"
      />
    </div>
  );
};

const App = () => {
  const [value, setValue] = useState("");

  useEffect(() => {
    setTimeout(() => {
      setValue("test");
    }, 1000);
  }, []);

  return <MyEditor value={value} onChange={setValue} />;
};

export default App;
```

下面的这里的核心问题代码，期望控制台输出的是`test`，但实际输出的却是 `""`。
```
  const handleChange = (e) => {
    console.log(value);
    onChange?.(e.getHtml());
  };
```

主要原因是因为`Editor`组件实例化editor时，传入的`config.onChange`一直引用在首次的props。
当`Editor`组件发生render时，事实上`onChange`已经发生改变了，但是editor内部调用的还是旧的`onChange`，导致回调方法`scope`内的变量都是旧值，包括`value`等。

修复思路：
事实上最好是能重新覆盖editor的config，但是考虑改动太大了，所以采用挂载的方式。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Enhanced event handling logic in the editor for improved responsiveness to content changes.
	- Streamlined connection between editor state and component props.
  
- **Bug Fixes**
	- Fixed issues related to change event management, ensuring more reliable onChange callbacks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->